### PR TITLE
[Add]レシピ詳細取得API追加

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,7 +24,6 @@ func main() {
 		log.Println("No .env file found")
 	}
 
-    
 	// Database configuration
 	dbConfig := database.GetConfigFromEnv()
 
@@ -65,6 +64,7 @@ func main() {
 	newsViewRepo := infraDB.NewNewsViewRepository(db)
 	tweetRepo := infraDB.NewTweetRepository(db)
 	tweetLikeRepo := infraDB.NewTweetLikeRepository(db)
+	recipeRepo := infraDB.NewRecipeRepository(db)
 
 	// Initialize email service
 	emailHost := os.Getenv("EMAIL_HOST")
@@ -100,6 +100,7 @@ func main() {
 	productUsecase := usecase.NewProductUsecase(productRepo, storeRepo, r2Service)
 	newsViewUsecase := usecase.NewNewsViewUsecase(newsViewRepo, storeRepo)
 	tweetUsecase := usecase.NewTweetUsecase(tweetRepo, tweetLikeRepo, storeRepo)
+	recipeUsecase := usecase.NewRecipeUsecase(recipeRepo)
 
 	// Initialize controllers
 	userController := controller.NewUserController(userUsecase)
@@ -110,9 +111,10 @@ func main() {
 	productController := controller.NewProductController(productUsecase)
 	newsViewController := controller.NewNewsViewController(newsViewUsecase)
 	tweetController := controller.NewTweetController(tweetUsecase)
+	recipeController := controller.NewRecipeController(recipeUsecase)
 
 	// Initialize router
-	r := router.NewRouter(userController, healthController, storeController, pushSubscriptionController, flyerController, productController, newsViewController, tweetController)
+	r := router.NewRouter(userController, healthController, storeController, pushSubscriptionController, flyerController, productController, newsViewController, tweetController, recipeController)
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/internal/domain/entity/recipe.go
+++ b/internal/domain/entity/recipe.go
@@ -1,0 +1,66 @@
+package entity
+
+import (
+	"time"
+)
+
+type Recipe struct {
+	ID            int64
+	RecipeID      string
+	Name          string
+	AuthorComment string
+	CookTime      int
+	Calories      int
+	TotalPrice    int
+	CookingPoint  string
+	ImageData     []byte
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	DeletedAt     *time.Time
+}
+
+type RecipeIngredient struct {
+	ID                 int64
+	RecipeIngredientID string
+	RecipeID           string
+	Name               string
+	DisplayOrder       int
+	AmountText         string
+	CreatedAt          time.Time
+	UpdatedAt          time.Time
+	DeletedAt          *time.Time
+}
+
+type RecipeSeasoning struct {
+	ID                int64
+	RecipeSeasoningID string
+	RecipeID          string
+	Name              string
+	DisplayOrder      int
+	AmountText        string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	DeletedAt         *time.Time
+}
+
+type RecipeStep struct {
+	ID           int64
+	RecipeStepID string
+	RecipeID     string
+	Instruction  string
+	StepNumber   int
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	DeletedAt    *time.Time
+}
+
+type SavedRecipe struct {
+	ID            int64
+	SavedRecipeID string
+	RecipeID      string
+	UserID        string
+	SavedAt       time.Time
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	DeletedAt     *time.Time
+}

--- a/internal/domain/repository/recipe_repository.go
+++ b/internal/domain/repository/recipe_repository.go
@@ -1,0 +1,13 @@
+package repository
+
+import (
+	"context"
+	"meguru-backend/internal/domain/entity"
+)
+
+type RecipeRepository interface {
+	GetRecipeByID(ctx context.Context, recipeID string) (*entity.Recipe, error)
+	GetRecipeIngredients(ctx context.Context, recipeID string) ([]*entity.RecipeIngredient, error)
+	GetRecipeSeasonings(ctx context.Context, recipeID string) ([]*entity.RecipeSeasoning, error)
+	GetRecipeSteps(ctx context.Context, recipeID string) ([]*entity.RecipeStep, error)
+}

--- a/internal/infrastructure/database/recipe_repository_impl.go
+++ b/internal/infrastructure/database/recipe_repository_impl.go
@@ -1,0 +1,134 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"meguru-backend/internal/domain/entity"
+	"meguru-backend/internal/domain/repository"
+)
+
+type RecipeRepositoryImpl struct {
+	db *sql.DB
+}
+
+func NewRecipeRepository(db *sql.DB) repository.RecipeRepository {
+	return &RecipeRepositoryImpl{db: db}
+}
+
+func (r *RecipeRepositoryImpl) GetRecipeByID(ctx context.Context, recipeID string) (*entity.Recipe, error) {
+	query := `
+		SELECT id, recipe_id, name, author_comment, cook_time, calories, total_price, cooking_point, image_data, created_at, updated_at
+		FROM recipes
+		WHERE recipe_id = $1 AND deleted_at IS NULL
+	`
+
+	recipe := &entity.Recipe{}
+	err := r.db.QueryRowContext(ctx, query, recipeID).Scan(
+		&recipe.ID, &recipe.RecipeID, &recipe.Name, &recipe.AuthorComment,
+		&recipe.CookTime, &recipe.Calories, &recipe.TotalPrice, &recipe.CookingPoint,
+		&recipe.ImageData, &recipe.CreatedAt, &recipe.UpdatedAt,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recipe by ID: %w", err)
+	}
+
+	return recipe, nil
+}
+
+func (r *RecipeRepositoryImpl) GetRecipeIngredients(ctx context.Context, recipeID string) ([]*entity.RecipeIngredient, error) {
+	query := `
+		SELECT id, recipe_ingredient_id, recipe_id, name, display_order, amount_text, created_at, updated_at
+		FROM recipe_ingredients
+		WHERE recipe_id = $1 AND deleted_at IS NULL
+		ORDER BY display_order
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, recipeID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recipe ingredients: %w", err)
+	}
+	defer rows.Close()
+
+	var ingredients []*entity.RecipeIngredient
+	for rows.Next() {
+		ingredient := &entity.RecipeIngredient{}
+		err := rows.Scan(
+			&ingredient.ID, &ingredient.RecipeIngredientID, &ingredient.RecipeID,
+			&ingredient.Name, &ingredient.DisplayOrder, &ingredient.AmountText,
+			&ingredient.CreatedAt, &ingredient.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan recipe ingredient: %w", err)
+		}
+		ingredients = append(ingredients, ingredient)
+	}
+
+	return ingredients, nil
+}
+
+func (r *RecipeRepositoryImpl) GetRecipeSeasonings(ctx context.Context, recipeID string) ([]*entity.RecipeSeasoning, error) {
+	query := `
+		SELECT id, recipe_seasoning_id, recipe_id, name, display_order, amount_text, created_at, updated_at
+		FROM recipe_seasonings
+		WHERE recipe_id = $1 AND deleted_at IS NULL
+		ORDER BY display_order
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, recipeID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recipe seasonings: %w", err)
+	}
+	defer rows.Close()
+
+	var seasonings []*entity.RecipeSeasoning
+	for rows.Next() {
+		seasoning := &entity.RecipeSeasoning{}
+		err := rows.Scan(
+			&seasoning.ID, &seasoning.RecipeSeasoningID, &seasoning.RecipeID,
+			&seasoning.Name, &seasoning.DisplayOrder, &seasoning.AmountText,
+			&seasoning.CreatedAt, &seasoning.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan recipe seasoning: %w", err)
+		}
+		seasonings = append(seasonings, seasoning)
+	}
+
+	return seasonings, nil
+}
+
+func (r *RecipeRepositoryImpl) GetRecipeSteps(ctx context.Context, recipeID string) ([]*entity.RecipeStep, error) {
+	query := `
+		SELECT id, recipe_step_id, recipe_id, instruction, step_number, created_at, updated_at
+		FROM recipe_steps
+		WHERE recipe_id = $1 AND deleted_at IS NULL
+		ORDER BY step_number
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, recipeID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recipe steps: %w", err)
+	}
+	defer rows.Close()
+
+	var steps []*entity.RecipeStep
+	for rows.Next() {
+		step := &entity.RecipeStep{}
+		err := rows.Scan(
+			&step.ID, &step.RecipeStepID, &step.RecipeID,
+			&step.Instruction, &step.StepNumber,
+			&step.CreatedAt, &step.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan recipe step: %w", err)
+		}
+		steps = append(steps, step)
+	}
+
+	return steps, nil
+}

--- a/internal/infrastructure/router/router.go
+++ b/internal/infrastructure/router/router.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func NewRouter(userController *controller.UserController, healthController *controller.HealthController, storeController *controller.StoreController, pushSubscriptionController *controller.PushSubscriptionController, flyerController *controller.FlyerController, productController *controller.ProductController, newsViewController *controller.NewsViewController, tweetController *controller.TweetController) *gin.Engine {
+func NewRouter(userController *controller.UserController, healthController *controller.HealthController, storeController *controller.StoreController, pushSubscriptionController *controller.PushSubscriptionController, flyerController *controller.FlyerController, productController *controller.ProductController, newsViewController *controller.NewsViewController, tweetController *controller.TweetController, recipeController *controller.RecipeController) *gin.Engine {
 	r := gin.Default()
 
 	// CORS設定
@@ -45,7 +45,7 @@ func NewRouter(userController *controller.UserController, healthController *cont
 			stores.GET("", storeController.GetAllStores)
 			stores.PUT("/:id", storeController.UpdateStore)
 			stores.POST("/signin", storeController.SignIn)
-			
+
 			// 認証が必要なエンドポイント
 			stores.GET("/profile", storeController.GetProfile)
 			stores.PUT("/profile", storeController.UpdateProfile)
@@ -58,11 +58,11 @@ func NewRouter(userController *controller.UserController, healthController *cont
 		flyer := api.Group("/flyer")
 		{
 			flyer.POST("/upload", flyerController.UploadFlyer)
-			flyer.GET("/nearby", flyerController.GetNearbyFlyers)  // 近隣店舗チラシ取得
+			flyer.GET("/nearby", flyerController.GetNearbyFlyers) // 近隣店舗チラシ取得
 			flyer.GET("/:store_id", flyerController.GetFlyerByStoreID)
 			flyer.GET("/all/:store_id", flyerController.GetAllFlyersByStoreID)
 		}
-		
+
 		// 商品関連のエンドポイント（認証必須）
 		products := api.Group("/products")
 		{
@@ -72,13 +72,13 @@ func NewRouter(userController *controller.UserController, healthController *cont
 			products.PUT("/:id", productController.UpdateStoreProduct)
 			products.DELETE("/:id", productController.DeleteStoreProduct)
 		}
-		
+
 		// ニュース閲覧関連のエンドポイント
 		news := api.Group("/news")
 		{
-			news.POST("/view", newsViewController.RecordNewsView)           // ニュース閲覧記録
+			news.POST("/view", newsViewController.RecordNewsView)                 // ニュース閲覧記録
 			news.GET("/view-count/:news_id", newsViewController.GetNewsViewCount) // 単一ニュース閲覧数
-			news.POST("/view-counts", newsViewController.GetNewsViewCounts) // 複数ニュース閲覧数
+			news.POST("/view-counts", newsViewController.GetNewsViewCounts)       // 複数ニュース閲覧数
 		}
 
 		// ツイート関連のエンドポイント
@@ -91,7 +91,13 @@ func NewRouter(userController *controller.UserController, healthController *cont
 			tweets.POST("/:id/like", tweetController.LikeTweet)
 			tweets.DELETE("/:id/like", tweetController.UnlikeTweet)
 		}
+
+		// レシピ関連のエンドポイント
+		recipes := api.Group("/recipes")
+		{
+			recipes.GET("/:recipe_id", recipeController.GetRecipeDetail)
+		}
 	}
 
 	return r
-} 
+}

--- a/internal/interface/controller/recipe_controller.go
+++ b/internal/interface/controller/recipe_controller.go
@@ -1,0 +1,36 @@
+package controller
+
+import (
+	"net/http"
+
+	"meguru-backend/internal/usecase"
+
+	"github.com/gin-gonic/gin"
+)
+
+type RecipeController struct {
+	recipeUsecase *usecase.RecipeUsecase
+}
+
+func NewRecipeController(recipeUsecase *usecase.RecipeUsecase) *RecipeController {
+	return &RecipeController{
+		recipeUsecase: recipeUsecase,
+	}
+}
+
+func (c *RecipeController) GetRecipeDetail(ctx *gin.Context) {
+	recipeID := ctx.Param("recipe_id")
+
+	recipeDetail, err := c.recipeUsecase.GetRecipeDetail(ctx.Request.Context(), recipeID)
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if recipeDetail == nil {
+		ctx.JSON(http.StatusNotFound, gin.H{"error": "recipe not found"})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"data": recipeDetail})
+}

--- a/internal/usecase/dto/recipes/recipe_response.go
+++ b/internal/usecase/dto/recipes/recipe_response.go
@@ -1,0 +1,46 @@
+package dto
+
+import (
+	"time"
+)
+
+type GetRecipeDetailResponse struct {
+	Recipe      *RecipeDetail       `json:"recipe"`
+	Ingredients []*RecipeIngredient `json:"ingredients"`
+	Seasonings  []*RecipeSeasoning  `json:"seasonings"`
+	Steps       []*RecipeStep       `json:"steps"`
+}
+
+type RecipeDetail struct {
+	ID            int64     `json:"id"`
+	RecipeID      string    `json:"recipe_id"`
+	Name          string    `json:"name"`
+	AuthorComment string    `json:"author_comment"`
+	CookTime      int       `json:"cook_time"`
+	Calories      int       `json:"calories"`
+	TotalPrice    int       `json:"total_price"`
+	CookingPoint  string    `json:"cooking_point"`
+	ImageData     []byte    `json:"image_data,omitempty"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+type RecipeIngredient struct {
+	ID           int64  `json:"id"`
+	Name         string `json:"name"`
+	DisplayOrder int    `json:"display_order"`
+	AmountText   string `json:"amount_text"`
+}
+
+type RecipeSeasoning struct {
+	ID           int64  `json:"id"`
+	Name         string `json:"name"`
+	DisplayOrder int    `json:"display_order"`
+	AmountText   string `json:"amount_text"`
+}
+
+type RecipeStep struct {
+	ID          int64  `json:"id"`
+	Instruction string `json:"instruction"`
+	StepNumber  int    `json:"step_number"`
+}

--- a/internal/usecase/recipe_usecase.go
+++ b/internal/usecase/recipe_usecase.go
@@ -1,0 +1,100 @@
+package usecase
+
+import (
+	"context"
+	"meguru-backend/internal/domain/repository"
+	dto "meguru-backend/internal/usecase/dto/recipes"
+)
+
+type RecipeUsecase struct {
+	recipeRepo repository.RecipeRepository
+}
+
+func NewRecipeUsecase(recipeRepo repository.RecipeRepository) *RecipeUsecase {
+	return &RecipeUsecase{
+		recipeRepo: recipeRepo,
+	}
+}
+
+func (u *RecipeUsecase) GetRecipeDetail(ctx context.Context, recipeID string) (*dto.GetRecipeDetailResponse, error) {
+	// レシピ基本情報を取得
+	recipe, err := u.recipeRepo.GetRecipeByID(ctx, recipeID)
+	if err != nil {
+		return nil, err
+	}
+	if recipe == nil {
+		return nil, nil
+	}
+
+	// 材料情報を取得
+	ingredients, err := u.recipeRepo.GetRecipeIngredients(ctx, recipeID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 調味料情報を取得
+	seasonings, err := u.recipeRepo.GetRecipeSeasonings(ctx, recipeID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 手順情報を取得
+	steps, err := u.recipeRepo.GetRecipeSteps(ctx, recipeID)
+	if err != nil {
+		return nil, err
+	}
+
+	// DTOに変換
+	recipeDetail := &dto.RecipeDetail{
+		ID:            recipe.ID,
+		RecipeID:      recipe.RecipeID,
+		Name:          recipe.Name,
+		AuthorComment: recipe.AuthorComment,
+		CookTime:      recipe.CookTime,
+		Calories:      recipe.Calories,
+		TotalPrice:    recipe.TotalPrice,
+		CookingPoint:  recipe.CookingPoint,
+		ImageData:     recipe.ImageData,
+		CreatedAt:     recipe.CreatedAt,
+		UpdatedAt:     recipe.UpdatedAt,
+	}
+
+	// 材料DTOに変換
+	var ingredientDTOs []*dto.RecipeIngredient
+	for _, ingredient := range ingredients {
+		ingredientDTOs = append(ingredientDTOs, &dto.RecipeIngredient{
+			ID:           ingredient.ID,
+			Name:         ingredient.Name,
+			DisplayOrder: ingredient.DisplayOrder,
+			AmountText:   ingredient.AmountText,
+		})
+	}
+
+	// 調味料DTOに変換
+	var seasoningDTOs []*dto.RecipeSeasoning
+	for _, seasoning := range seasonings {
+		seasoningDTOs = append(seasoningDTOs, &dto.RecipeSeasoning{
+			ID:           seasoning.ID,
+			Name:         seasoning.Name,
+			DisplayOrder: seasoning.DisplayOrder,
+			AmountText:   seasoning.AmountText,
+		})
+	}
+
+	// 手順DTOに変換
+	var stepDTOs []*dto.RecipeStep
+	for _, step := range steps {
+		stepDTOs = append(stepDTOs, &dto.RecipeStep{
+			ID:          step.ID,
+			Instruction: step.Instruction,
+			StepNumber:  step.StepNumber,
+		})
+	}
+
+	return &dto.GetRecipeDetailResponse{
+		Recipe:      recipeDetail,
+		Ingredients: ingredientDTOs,
+		Seasonings:  seasoningDTOs,
+		Steps:       stepDTOs,
+	}, nil
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: レシピ詳細取得APIを追加しました。これにより、ユーザーは特定のレシピIDに基づいてレシピの詳細情報を取得できるようになりました。
- New Feature: 新しいエンドポイント`/recipes/:recipe_id`が追加され、レシピの材料、調味料、手順などの詳細情報を含むレスポンスを提供します。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - レシピ詳細APIを追加（/api/v1/recipes/:recipe_id）。指定IDのレシピ情報を取得し、材料・調味料・手順を含む詳細をJSONで返します。
  - 材料は表示順、手順はステップ番号で並び替えて返却します。
  - 既存機能への影響はなく、APIルーティングの追加のみです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->