### PR TITLE
Get saved recipe

### DIFF
--- a/internal/domain/repository/recipe_repository.go
+++ b/internal/domain/repository/recipe_repository.go
@@ -13,4 +13,5 @@ type RecipeRepository interface {
 	SearchRecipesByIngredients(ctx context.Context, ingredientNames []string) ([]*entity.Recipe, error)
 	SaveRecipe(ctx context.Context, savedRecipe *entity.SavedRecipe) error
 	GetSavedRecipeByUserAndRecipe(ctx context.Context, userID, recipeID string) (*entity.SavedRecipe, error)
+	GetSavedRecipesByUser(ctx context.Context, userID string) ([]*entity.SavedRecipe, error)
 }

--- a/internal/infrastructure/database/recipe_repository_impl.go
+++ b/internal/infrastructure/database/recipe_repository_impl.go
@@ -220,3 +220,38 @@ func (r *RecipeRepositoryImpl) GetSavedRecipeByUserAndRecipe(ctx context.Context
 
 	return savedRecipe, nil
 }
+
+func (r *RecipeRepositoryImpl) GetSavedRecipesByUser(ctx context.Context, userID string) ([]*entity.SavedRecipe, error) {
+	query := `
+		SELECT id, saved_recipe_id, recipe_id, user_id, saved_at, created_at, updated_at
+		FROM saved_recipes
+		WHERE user_id = $1 AND deleted_at IS NULL
+		ORDER BY saved_at DESC
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get saved recipes by user: %w", err)
+	}
+	defer rows.Close()
+
+	var savedRecipes []*entity.SavedRecipe
+	for rows.Next() {
+		savedRecipe := &entity.SavedRecipe{}
+		err := rows.Scan(
+			&savedRecipe.ID,
+			&savedRecipe.SavedRecipeID,
+			&savedRecipe.RecipeID,
+			&savedRecipe.UserID,
+			&savedRecipe.SavedAt,
+			&savedRecipe.CreatedAt,
+			&savedRecipe.UpdatedAt,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan saved recipe: %w", err)
+		}
+		savedRecipes = append(savedRecipes, savedRecipe)
+	}
+
+	return savedRecipes, nil
+}

--- a/internal/infrastructure/router/router.go
+++ b/internal/infrastructure/router/router.go
@@ -107,6 +107,7 @@ func NewRouter(userController *controller.UserController, healthController *cont
 		savedRecipes.Use(UserAuthMiddleware(jwtService))
 		{
 			savedRecipes.POST("", recipeController.SaveRecipe)
+			savedRecipes.GET("", recipeController.GetSavedRecipes)
 		}
 	}
 

--- a/internal/interface/controller/recipe_controller.go
+++ b/internal/interface/controller/recipe_controller.go
@@ -75,3 +75,20 @@ func (c *RecipeController) SaveRecipe(ctx *gin.Context) {
 
 	ctx.JSON(http.StatusOK, gin.H{"data": result})
 }
+
+func (c *RecipeController) GetSavedRecipes(ctx *gin.Context) {
+	// JWTトークンからユーザーIDを取得
+	userID, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "user not authenticated"})
+		return
+	}
+
+	result, err := c.recipeUsecase.GetSavedRecipes(ctx.Request.Context(), userID.(string))
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"data": result})
+}

--- a/internal/usecase/dto/recipes/recipe_response.go
+++ b/internal/usecase/dto/recipes/recipe_response.go
@@ -5,10 +5,12 @@ import (
 )
 
 type GetRecipeDetailResponse struct {
-	Recipe      *RecipeDetail       `json:"recipe"`
-	Ingredients []*RecipeIngredient `json:"ingredients"`
-	Seasonings  []*RecipeSeasoning  `json:"seasonings"`
-	Steps       []*RecipeStep       `json:"steps"`
+	RecipeID    string   `json:"recipe_id"`
+	Name        string   `json:"name"`
+	CookTime    int      `json:"cook_time"`
+	Calories    int      `json:"calories"`
+	Ingredients []string `json:"ingredients"`
+	Seasonings  []string `json:"seasonings"`
 }
 
 type RecipeDetail struct {

--- a/internal/usecase/recipe_usecase.go
+++ b/internal/usecase/recipe_usecase.go
@@ -47,64 +47,25 @@ func (u *RecipeUsecase) GetRecipeDetail(ctx context.Context, recipeID string) (*
 		return nil, err
 	}
 
-	// 手順情報を取得
-	steps, err := u.recipeRepo.GetRecipeSteps(ctx, recipeID)
-	if err != nil {
-		return nil, err
-	}
-
-	// DTOに変換
-	recipeDetail := &dto.RecipeDetail{
-		ID:            recipe.ID,
-		RecipeID:      recipe.RecipeID,
-		Name:          recipe.Name,
-		AuthorComment: recipe.AuthorComment,
-		CookTime:      recipe.CookTime,
-		Calories:      recipe.Calories,
-		TotalPrice:    recipe.TotalPrice,
-		CookingPoint:  recipe.CookingPoint,
-		ImageData:     recipe.ImageData,
-		CreatedAt:     recipe.CreatedAt,
-		UpdatedAt:     recipe.UpdatedAt,
-	}
-
-	// 材料DTOに変換
-	var ingredientDTOs []*dto.RecipeIngredient
+	// 材料名のリストを作成
+	var ingredientNames []string
 	for _, ingredient := range ingredients {
-		ingredientDTOs = append(ingredientDTOs, &dto.RecipeIngredient{
-			ID:           ingredient.ID,
-			Name:         ingredient.Name,
-			DisplayOrder: ingredient.DisplayOrder,
-			AmountText:   ingredient.AmountText,
-		})
+		ingredientNames = append(ingredientNames, ingredient.Name)
 	}
 
-	// 調味料DTOに変換
-	var seasoningDTOs []*dto.RecipeSeasoning
+	// 調味料名のリストを作成
+	var seasoningNames []string
 	for _, seasoning := range seasonings {
-		seasoningDTOs = append(seasoningDTOs, &dto.RecipeSeasoning{
-			ID:           seasoning.ID,
-			Name:         seasoning.Name,
-			DisplayOrder: seasoning.DisplayOrder,
-			AmountText:   seasoning.AmountText,
-		})
-	}
-
-	// 手順DTOに変換
-	var stepDTOs []*dto.RecipeStep
-	for _, step := range steps {
-		stepDTOs = append(stepDTOs, &dto.RecipeStep{
-			ID:          step.ID,
-			Instruction: step.Instruction,
-			StepNumber:  step.StepNumber,
-		})
+		seasoningNames = append(seasoningNames, seasoning.Name)
 	}
 
 	return &dto.GetRecipeDetailResponse{
-		Recipe:      recipeDetail,
-		Ingredients: ingredientDTOs,
-		Seasonings:  seasoningDTOs,
-		Steps:       stepDTOs,
+		RecipeID:    recipe.RecipeID,
+		Name:        recipe.Name,
+		CookTime:    recipe.CookTime,
+		Calories:    recipe.Calories,
+		Ingredients: ingredientNames,
+		Seasonings:  seasoningNames,
 	}, nil
 }
 
@@ -211,5 +172,67 @@ func (u *RecipeUsecase) SaveRecipe(ctx context.Context, req *dto.SaveRecipeReque
 		UserID:        savedRecipe.UserID,
 		SavedAt:       savedRecipe.SavedAt,
 		Message:       "Recipe saved successfully",
+	}, nil
+}
+
+func (u *RecipeUsecase) GetSavedRecipes(ctx context.Context, userID string) (*dto.GetRecipesByImageResponse, error) {
+	// 1. ユーザーが保存したレシピ一覧を取得
+	savedRecipes, err := u.recipeRepo.GetSavedRecipesByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2. 各保存レシピの詳細情報を取得
+	var recipeResults []*dto.RecipeResult
+	for _, savedRecipe := range savedRecipes {
+		// レシピ詳細情報を取得
+		recipe, err := u.recipeRepo.GetRecipeByID(ctx, savedRecipe.RecipeID)
+		if err != nil {
+			return nil, err
+		}
+		if recipe == nil {
+			// レシピが削除されている場合はスキップ
+			continue
+		}
+
+		// 材料情報を取得
+		ingredients, err := u.recipeRepo.GetRecipeIngredients(ctx, savedRecipe.RecipeID)
+		if err != nil {
+			return nil, err
+		}
+
+		// 調味料情報を取得
+		seasonings, err := u.recipeRepo.GetRecipeSeasonings(ctx, savedRecipe.RecipeID)
+		if err != nil {
+			return nil, err
+		}
+
+		// 材料名のリストを作成
+		var ingredientNames []string
+		for _, ingredient := range ingredients {
+			ingredientNames = append(ingredientNames, ingredient.Name)
+		}
+
+		// 調味料名のリストを作成
+		var seasoningNames []string
+		for _, seasoning := range seasonings {
+			seasoningNames = append(seasoningNames, seasoning.Name)
+		}
+
+		// レシピ詳細DTOを作成
+		recipeResult := &dto.RecipeResult{
+			RecipeID:    recipe.RecipeID,
+			Name:        recipe.Name,
+			CookTime:    recipe.CookTime,
+			Calories:    recipe.Calories,
+			Ingredients: ingredientNames,
+			Seasonings:  seasoningNames,
+		}
+
+		recipeResults = append(recipeResults, recipeResult)
+	}
+
+	return &dto.GetRecipesByImageResponse{
+		Recipes: recipeResults,
 	}, nil
 }


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- 新機能: ユーザーが保存したレシピを取得するための新しいエンドポイント `/saved-recipes` を追加しました。これにより、ユーザーは自分の保存済みレシピを簡単に管理できます。
- 新機能: `RecipeController` に保存されたレシピを取得するメソッドを追加し、認証されたユーザーのみがアクセス可能です。
- リファクタリング: レシピ詳細情報の構造体と取得関数を簡略化し、材料と調味料の名前リストを返すように変更しました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 保存済みレシピ一覧取得を追加。認証ユーザーは GET /api/v1/saved-recipes で取得、POST 同パスで保存可能。
- リファクタ
  - レシピ詳細APIのレスポンスをフラット化。recipe_id/name/cook_time/calories/ingredients/seasonings のみ返却。steps は削除。
  - 保存レシピ関連エンドポイントを /api/v1/saved-recipes に移動。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->