### PR TITLE
[Add]レシピ保存解除API

### DIFF
--- a/internal/domain/repository/recipe_repository.go
+++ b/internal/domain/repository/recipe_repository.go
@@ -14,4 +14,6 @@ type RecipeRepository interface {
 	SaveRecipe(ctx context.Context, savedRecipe *entity.SavedRecipe) error
 	GetSavedRecipeByUserAndRecipe(ctx context.Context, userID, recipeID string) (*entity.SavedRecipe, error)
 	GetSavedRecipesByUser(ctx context.Context, userID string) ([]*entity.SavedRecipe, error)
+	GetSavedRecipeByID(ctx context.Context, savedRecipeID string) (*entity.SavedRecipe, error)
+	DeleteSavedRecipe(ctx context.Context, userID, recipeID string) error
 }

--- a/internal/infrastructure/database/recipe_repository_impl.go
+++ b/internal/infrastructure/database/recipe_repository_impl.go
@@ -255,3 +255,55 @@ func (r *RecipeRepositoryImpl) GetSavedRecipesByUser(ctx context.Context, userID
 
 	return savedRecipes, nil
 }
+
+func (r *RecipeRepositoryImpl) GetSavedRecipeByID(ctx context.Context, savedRecipeID string) (*entity.SavedRecipe, error) {
+	query := `
+		SELECT id, saved_recipe_id, recipe_id, user_id, saved_at, created_at, updated_at
+		FROM saved_recipes
+		WHERE saved_recipe_id = $1 AND deleted_at IS NULL
+	`
+
+	savedRecipe := &entity.SavedRecipe{}
+	err := r.db.QueryRowContext(ctx, query, savedRecipeID).Scan(
+		&savedRecipe.ID,
+		&savedRecipe.SavedRecipeID,
+		&savedRecipe.RecipeID,
+		&savedRecipe.UserID,
+		&savedRecipe.SavedAt,
+		&savedRecipe.CreatedAt,
+		&savedRecipe.UpdatedAt,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get saved recipe by ID: %w", err)
+	}
+
+	return savedRecipe, nil
+}
+
+func (r *RecipeRepositoryImpl) DeleteSavedRecipe(ctx context.Context, userID, recipeID string) error {
+	query := `
+		UPDATE saved_recipes
+		SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+		WHERE user_id = $1 AND recipe_id = $2 AND deleted_at IS NULL
+	`
+
+	result, err := r.db.ExecContext(ctx, query, userID, recipeID)
+	if err != nil {
+		return fmt.Errorf("failed to delete saved recipe: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return fmt.Errorf("saved recipe not found or already deleted")
+	}
+
+	return nil
+}

--- a/internal/infrastructure/router/router.go
+++ b/internal/infrastructure/router/router.go
@@ -116,7 +116,7 @@ func NewRouter(userController *controller.UserController, healthController *cont
 		{
 			savedRecipes.POST("", recipeController.SaveRecipe)
 			savedRecipes.GET("", recipeController.GetSavedRecipes)
-			savedRecipes.DELETE("", recipeController.DeleteSavedRecipe)
+			savedRecipes.DELETE("/:recipe_id", recipeController.DeleteSavedRecipe)
 		}
 	}
 

--- a/internal/infrastructure/router/router.go
+++ b/internal/infrastructure/router/router.go
@@ -39,7 +39,7 @@ func NewRouter(userController *controller.UserController, healthController *cont
 			users.POST("/login", userController.LoginUser)
 			users.POST("/forgot-password", userController.ForgotPassword)
 			users.POST("/reset-password", userController.ResetPassword)
-			
+
 			// 認証が必要なエンドポイント
 			protected := users.Group("")
 			protected.Use(UserAuthMiddleware(jwtService))
@@ -116,6 +116,7 @@ func NewRouter(userController *controller.UserController, healthController *cont
 		{
 			savedRecipes.POST("", recipeController.SaveRecipe)
 			savedRecipes.GET("", recipeController.GetSavedRecipes)
+			savedRecipes.DELETE("", recipeController.DeleteSavedRecipe)
 		}
 	}
 

--- a/internal/interface/controller/recipe_controller.go
+++ b/internal/interface/controller/recipe_controller.go
@@ -92,3 +92,26 @@ func (c *RecipeController) GetSavedRecipes(ctx *gin.Context) {
 
 	ctx.JSON(http.StatusOK, gin.H{"data": result})
 }
+
+func (c *RecipeController) DeleteSavedRecipe(ctx *gin.Context) {
+	// JWTトークンからユーザーIDを取得
+	userID, exists := ctx.Get("user_id")
+	if !exists {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "user not authenticated"})
+		return
+	}
+
+	var req dto.DeleteSavedRecipeRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	result, err := c.recipeUsecase.DeleteSavedRecipe(ctx.Request.Context(), &req, userID.(string))
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"data": result})
+}

--- a/internal/interface/controller/recipe_controller.go
+++ b/internal/interface/controller/recipe_controller.go
@@ -101,13 +101,19 @@ func (c *RecipeController) DeleteSavedRecipe(ctx *gin.Context) {
 		return
 	}
 
-	var req dto.DeleteSavedRecipeRequest
-	if err := ctx.ShouldBindJSON(&req); err != nil {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	// パスパラメータからrecipe_idを取得
+	recipeID := ctx.Param("recipe_id")
+	if recipeID == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "recipe_id is required"})
 		return
 	}
 
-	result, err := c.recipeUsecase.DeleteSavedRecipe(ctx.Request.Context(), &req, userID.(string))
+	// リクエストDTOを作成
+	req := &dto.DeleteSavedRecipeRequest{
+		RecipeID: recipeID,
+	}
+
+	result, err := c.recipeUsecase.DeleteSavedRecipe(ctx.Request.Context(), req, userID.(string))
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/usecase/dto/recipes/delete_saved_recipe_request.go
+++ b/internal/usecase/dto/recipes/delete_saved_recipe_request.go
@@ -1,0 +1,5 @@
+package dto
+
+type DeleteSavedRecipeRequest struct {
+	RecipeID string `json:"recipe_id" binding:"required"`
+}

--- a/internal/usecase/dto/recipes/delete_saved_recipe_response.go
+++ b/internal/usecase/dto/recipes/delete_saved_recipe_response.go
@@ -1,0 +1,5 @@
+package dto
+
+type DeleteSavedRecipeResponse struct {
+	Message string `json:"message"`
+}

--- a/internal/usecase/recipe_usecase.go
+++ b/internal/usecase/recipe_usecase.go
@@ -280,3 +280,24 @@ func (u *RecipeUsecase) GetSavedRecipes(ctx context.Context, userID string) (*dt
 		Recipes: recipeResults,
 	}, nil
 }
+
+func (u *RecipeUsecase) DeleteSavedRecipe(ctx context.Context, req *dto.DeleteSavedRecipeRequest, userID string) (*dto.DeleteSavedRecipeResponse, error) {
+	// 1. 保存レシピが存在するかチェック
+	savedRecipe, err := u.recipeRepo.GetSavedRecipeByUserAndRecipe(ctx, userID, req.RecipeID)
+	if err != nil {
+		return nil, err
+	}
+	if savedRecipe == nil {
+		return nil, errors.New("saved recipe not found")
+	}
+
+	// 2. 保存レシピを削除（論理削除）
+	err = u.recipeRepo.DeleteSavedRecipe(ctx, userID, req.RecipeID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &dto.DeleteSavedRecipeResponse{
+		Message: "Recipe removed from saved recipes successfully",
+	}, nil
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- 新機能: 保存されたレシピを削除するAPIエンドポイントを追加しました。ユーザーは特定のレシピを保存リストから削除できるようになりました。
- 新機能: `DeleteSavedRecipe`メソッドにより、ユーザー認証を通じてレシピの論理削除が可能になりました。
- 新機能: レシピ削除リクエストとレスポンス用のデータ構造を追加し、APIのリクエスト処理を改善しました。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 保存済みレシピの削除に対応しました。API利用者は DELETE /api/v1/saved-recipes を呼び出すことで、指定したレシピを保存一覧から削除できます。
  - リクエストでは recipe_id を必須項目として受け付け、認証が必要です。入力不備や未認証時は適切なエラーレスポンスを返します。
  - 成功時には削除完了メッセージを含むレスポンスを返却します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->