### PR TITLE
[Add]画像から抽出した食材を返却値に含める

### DIFF
--- a/internal/usecase/dto/recipes/get_recipes_by_image_response.go
+++ b/internal/usecase/dto/recipes/get_recipes_by_image_response.go
@@ -1,7 +1,8 @@
 package dto
 
 type GetRecipesByImageResponse struct {
-	Recipes []*RecipeResult `json:"recipes"`
+	ExtractedIngredients []string        `json:"extracted_ingredients"`
+	Recipes              []*RecipeResult `json:"recipes"`
 }
 
 type RecipeResult struct {

--- a/internal/usecase/recipe_usecase.go
+++ b/internal/usecase/recipe_usecase.go
@@ -170,7 +170,8 @@ func (u *RecipeUsecase) GetRecipesByImage(ctx context.Context, req *dto.GetRecip
 	}
 
 	return &dto.GetRecipesByImageResponse{
-		Recipes: searchResults,
+		ExtractedIngredients: ingredientNames,
+		Recipes:              searchResults,
 	}, nil
 }
 
@@ -277,7 +278,8 @@ func (u *RecipeUsecase) GetSavedRecipes(ctx context.Context, userID string) (*dt
 	}
 
 	return &dto.GetRecipesByImageResponse{
-		Recipes: recipeResults,
+		ExtractedIngredients: []string{}, // 保存レシピには抽出された食材はないため空配列
+		Recipes:              recipeResults,
 	}, nil
 }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- 新機能: `GetRecipesByImageResponse`に`ExtractedIngredients`フィールドを追加し、画像から抽出された食材情報を提供。
- 新機能: `GetRecipesByImage`関数が画像から抽出した食材名を返すように更新。
- 新機能: `GetSavedRecipes`関数で`ExtractedIngredients`として空の配列を返すように変更。 

これらの変更により、ユーザーは画像から得られる食材情報をより簡単に取得できるようになります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->